### PR TITLE
Minor Linting Corrections

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,22 @@
+name: Go
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.20.2
+
+    - name: Test
+      run: |
+        go test -v

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
 
 jobs:
-  build:
+  run_tests:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -17,6 +17,6 @@ jobs:
       with:
         go-version: 1.20.2
 
-    - name: Test
+    - name: Run Tests
       run: |
         go test -v

--- a/context/mint.go
+++ b/context/mint.go
@@ -49,7 +49,7 @@ func Emit[T any](e *Emitter, ctx context.Context, v T) error {
 	for _, fn := range e.plugins {
 		after := fn(ctx, v)
 		if after != nil {
-			func() { defer after() }()
+			defer after()
 		}
 	}
 

--- a/context/mint.go
+++ b/context/mint.go
@@ -49,7 +49,7 @@ func Emit[T any](e *Emitter, ctx context.Context, v T) error {
 	for _, fn := range e.plugins {
 		after := fn(ctx, v)
 		if after != nil {
-			defer after()
+			func() { defer after() }()
 		}
 	}
 

--- a/context/mint.go
+++ b/context/mint.go
@@ -28,9 +28,9 @@ func (e *Emitter) init() {
 	}
 }
 
-// Sequentially pushes value v to all consumers of type T.
+// Emit Sequentially pushes value v to all consumers of type T.
 // Receive order is indetermenistic. Cancelling ctx waits
-// for active consumer to return and stops emiting further.
+// for active consumer to return and stops emitting further.
 //
 // Using nil context will use context.Background() instead.
 // error is always ctx.Err()
@@ -68,7 +68,7 @@ func Emit[T any](e *Emitter, ctx context.Context, v T) error {
 	return ctx.Err()
 }
 
-// Registers a new consumer that receives all values which were
+// On Registers a new consumer that receives all values which were
 // emitted as T. So that On(e, func(context.Context, any)) will
 // receive all values emitted with Emit[any](e, ...)
 //
@@ -110,7 +110,7 @@ func On[T any](e *Emitter, fn func(context.Context, T)) (off func() <-chan struc
 	}
 }
 
-// Use allows to hook into event emitting process. Plugns are
+// Use allows to hook into event emitting process. Plugins are
 // called sequentially in order they were added to Emitter.
 // Plugin is a function that takes Emitted values and
 // returns nil or a function that will be called after

--- a/mint.go
+++ b/mint.go
@@ -18,7 +18,8 @@ type Emitter = cm.Emitter
 // Emit Sequentially pushes value v to all consumers of type T.
 // Receive order is indetermenistic.
 func Emit[T any](e *Emitter, v T) {
-	cm.Emit(e, context.Background(), v)
+	// todo: decide how to handle context.Err()
+	_ = cm.Emit(e, context.Background(), v)
 }
 
 // On Registers a new consumer that receives all values which were

--- a/mint.go
+++ b/mint.go
@@ -18,7 +18,6 @@ type Emitter = cm.Emitter
 // Emit Sequentially pushes value v to all consumers of type T.
 // Receive order is indetermenistic.
 func Emit[T any](e *Emitter, v T) {
-	// todo: decide how to handle context.Err()
 	_ = cm.Emit(e, context.Background(), v)
 }
 

--- a/mint.go
+++ b/mint.go
@@ -15,13 +15,13 @@ import (
 // Emitter holds all active consumers and Emit hooks.
 type Emitter = cm.Emitter
 
-// Sequentially pushes value v to all consumers of type T.
+// Emit Sequentially pushes value v to all consumers of type T.
 // Receive order is indetermenistic.
 func Emit[T any](e *Emitter, v T) {
 	cm.Emit(e, context.Background(), v)
 }
 
-// Registers a new consumer that receives all values which were
+// On Registers a new consumer that receives all values which were
 // emitted as T. So that On(e, func(any)) will
 // receive all values emitted with Emit[any](e, ...)
 //
@@ -33,7 +33,7 @@ func On[T any](e *Emitter, fn func(T)) (off func() <-chan struct{}) {
 	return cm.On(e, func(_ context.Context, v T) { fn(v) })
 }
 
-// Use allows to hook into event emitting process. Plugns are
+// Use allows to hook into event emitting process. Plugins are
 // called sequentially in order they were added to Emitter.
 // Plugin is a function that takes Emitted values and
 // returns nil or a function that will be called after

--- a/mint_test.go
+++ b/mint_test.go
@@ -116,15 +116,17 @@ func TestContextNoEmitter(t *testing.T) {
 func TestUse(t *testing.T) {
 	e := new(mint.Emitter)
 
-	var before, after bool
+	s := make([]int, 0, 3)
 	mint.Use(e, func(any) func() {
-		before = true
-		return func() { after = true }
+		s = append(s, 1)
+		return func() { s = append(s, 3) }
 	})
+
+	mint.On(e, func(e event) { s = append(s, 2) })
 
 	mint.Emit(e, event{})
 
-	if !before || !after {
-		t.Fatalf("plugin was not called; before: %t, after: %t", before, after)
+	if len(s) != 3 || s[0] != 1 || s[1] != 2 || s[2] != 3 {
+		t.Fatalf("plugin was called in incorrect order: expected %v, got %v", []int{1, 2, 3}, s)
 	}
 }

--- a/mint_test.go
+++ b/mint_test.go
@@ -100,7 +100,7 @@ func TestContextCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	ctxmint.Emit(e, ctx, event{})
+	_ = ctxmint.Emit(e, ctx, event{})
 }
 
 func TestUse(t *testing.T) {

--- a/mint_test.go
+++ b/mint_test.go
@@ -100,7 +100,10 @@ func TestContextCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_ = ctxmint.Emit(e, ctx, event{})
+	err := ctxmint.Emit(e, ctx, event{})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled; got %v", err)
+	}
 }
 
 func TestContextNoEmitter(t *testing.T) {

--- a/mint_test.go
+++ b/mint_test.go
@@ -103,6 +103,13 @@ func TestContextCancel(t *testing.T) {
 	_ = ctxmint.Emit(e, ctx, event{})
 }
 
+func TestContextNoEmitter(t *testing.T) {
+	ctx := context.Background()
+	if err := ctxmint.Emit(nil, ctx, event{}); err != nil {
+		t.Errorf("expected error; got %v", err)
+	}
+}
+
 func TestUse(t *testing.T) {
 	e := new(mint.Emitter)
 


### PR DESCRIPTION
Fixed some function comments and spelling mistakes.
Added additional test to validate a nil-Emitter scenario.

Raised a TODO in mint.go:21/22 as the context/mint.go passes an unhandled context.Err to the main function. Currently have this handled with a throwaway.